### PR TITLE
Updating For breaking typings changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+node_modules
+typings

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "preversion": "npm test"
   },
   "dependencies": {
-    "@angular/http": "2.0.0-rc.3",
+    "@angular/http": "2.0.0-rc.4",
     "@angular/common": "2.0.0-rc.3",
     "@angular/compiler": "2.0.0-rc.3",
     "@angular/core": "2.0.0-rc.3",
-    "@angular/forms": "^0.1.0",
+    "@angular/forms": "^0.2.0",
     "@angular/platform-browser": "2.0.0-rc.3",
     "@angular/platform-browser-dynamic": "2.0.0-rc.3",
     "@angular/platform-server": "2.0.0-rc.3",

--- a/typings.json
+++ b/typings.json
@@ -1,10 +1,9 @@
 {
   "dependencies": {
-    "moment": "registry:npm/moment#2.10.5+20160211003958",
-    "zone.js": "github:gdi2290/typed-zone.js#66ea8a3451542bb7798369306840e46be1d6ec89"
+    "moment": "registry:npm/moment#2.10.5+20160211003958"
   },
   "devDependencies": {},
-  "ambientDependencies": {
+  "globalDependencies": {
     "core-js": "registry:dt/core-js#0.0.0+20160317120654",
     "greensock": "registry:dt/greensock#1.15.1+20160316155526",
     "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#74a4dfc1bc2dfadec47b8aae953b28546cb9c6b7",
@@ -13,6 +12,7 @@
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#8cf8164641be73e8f1e652c2a5b967c7210b6729",
     "selenium-webdriver": "github:DefinitelyTyped/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#a83677ed13add14c2ab06c7325d182d0ba2784ea",
     "underscore": "registry:dt/underscore#1.7.0+20160505190121",
-    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4"
+    "webpack": "github:DefinitelyTyped/DefinitelyTyped/webpack/webpack.d.ts#95c02169ba8fa58ac1092422efbd2e3174a206f4",
+    "zone.js": "github:gdi2290/typed-zone.js#66ea8a3451542bb7798369306840e46be1d6ec89"
   }
 }


### PR DESCRIPTION
Updates typings dependencies config to meet new changes for typings v 1.0.x.

Also updates some dependencies to more recent versions to avoid `UNMET PEER DEPENDENCY` error.

You may want to put the existing version into another branch so that anyone using the older version of typings can still utilise this repo.
